### PR TITLE
Fix connection leak in ReportController causing CLOSE_WAIT connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Analysis Service is token based, so for every analysis request a TOKEN is associ
 ##### Git Clone
 
 ```console
-git clone https://github.com/reactome/AnalysisTools.git
-cd AnalysisTools; cd Service
+git clone https://github.com/reactome/AnalysisService.git
+cd AnalysisService
 ```
 
 ##### Configuring Maven Profile :memo:


### PR DESCRIPTION
Fixed CloseableHttpResponse not being closed in the report() method. This was causing connections to remain in CLOSE_WAIT state when reporting PDF generation metrics to the report service.

Changed to use try-with-resources pattern to ensure both CloseableHttpClient and CloseableHttpResponse are properly closed after use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@EliotRagueneau, @jweiser and I worked on this repo in addition to the content service where we have another PR. We are trying to fix the CLOSE_WAIT connections. We realize that you are on vacation. If you are not able to work on this that is fine. What we did so far was change the code and compiled it. If we need to we would be willing to roll it out into production. We just need to know if what is on production is from the latest commit on the master branch. And if there is anything else we should know about deploying it?  we will make sure to test to see that it is running correctly and monitor it when it is deployed.  